### PR TITLE
Cambios en la apariencia del menú principal, comentado código original para su posterior eliminación 

### DIFF
--- a/src/jbake/assets/js/main.js
+++ b/src/jbake/assets/js/main.js
@@ -1,5 +1,7 @@
 jQuery(document).ready(function( $ ) {
 
+  activeMenu();
+
   // Back to top button
   $(window).scroll(function() {
     if ($(this).scrollTop() > 100) {
@@ -148,7 +150,23 @@ $("ul.nav-menu li").click(function() {
   $(this).addClass("menu-active");
 });
 
-$('#nav-menu-container > ul.nav-menu > li:first-child').addClass("menu-active");
+function activeMenu() {
+  var path = window.location.pathname;
+  path = path.replace(/\/$/, "");
+  path = decodeURIComponent(path);
+
+  $("#nav-menu-container > ul.nav-menu a").each(function () {
+      var href = $(this).attr('href');
+
+      if (path.substring(0, href.length) === href) {
+          $(this).closest('li').addClass('menu-active');
+      }
+  
+  });
+}
+
+// comentando codigo original para poner el subrayado al menú principal 
+//$('#nav-menu-container > ul.nav-menu > li:first-child').addClass("menu-active");
 
 $('.nav-tabs > li > a').click(function(event){
   event.preventDefault();//stop browser to take action for clicked anchor

--- a/src/jbake/templates/menu.thyme
+++ b/src/jbake/templates/menu.thyme
@@ -10,19 +10,18 @@
 
 			<div id="logo" class="pull-left">
 				 <!-- <h1><a href="index.html"><span>JConf</span>Dominicana</a></h1>-->
-				<a href="index.html" class="scrollto"><img src="img/jconf-sm-logo.png" alt="" title="JConf Dominicana"></a>
-
+				<a href="/index.html" class="scrollto"><img src="img/jconf-sm-logo.png" alt="" title="JConf Dominicana"></a>
 			</div>
 
 			<nav id="nav-menu-container">
 				<ul class="nav-menu">
-					<li><a href="index.html">Home</a></li>
-					<li><a href="buy-tickets.html">Tickets</a></li>
-					<li><a href="schedule.html">Agenda</a></li>
-					<li><a href="speakers.html">Speakers</a></li>
-					<li><a href="code-of-conduct.html">Code of conduct</a></li>
-					<li><a href="index.html#sponsors">Sponsors</a></li>
-					<li><a href="about.html">About</a></li>
+					<li><a href="/index.html">Home</a></li>
+					<li><a href="/buy-tickets.html">Tickets</a></li>
+					<li><a href="/schedule.html">Agenda</a></li>
+					<li><a href="/speakers.html">Speakers</a></li>
+					<li><a href="/code-of-conduct.html">Code of conduct</a></li>
+					<li><a href="/index.html#sponsors">Sponsors</a></li>
+					<li><a href="/about.html">About</a></li>
 				</ul>
 			</nav><!-- #nav-menu-container -->
 		</div>


### PR DESCRIPTION
La página solo subrayaba la opción <Home>, no importa a cual opción del menú entrabas, ahora se subraya el menú actual donde estas.